### PR TITLE
MULE-12327: ArtifactClassLoaderRunner - Application URLs are also

### DIFF
--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AuthorizationCodeAuthorizationFailureTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AuthorizationCodeAuthorizationFailureTestCase.java
@@ -25,9 +25,9 @@ import static org.mule.service.oauth.internal.OAuthConstants.STATE_PARAMETER;
 import static org.mule.tck.MuleTestUtils.testWithSystemProperty;
 
 import org.mule.extension.oauth2.internal.tokenmanager.TokenManagerConfig;
-import org.mule.functional.api.component.FlowAssert;
 import org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext;
 import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.tck.processor.FlowAssert;
 
 import java.io.IOException;
 


### PR DESCRIPTION
including transitive dependencies from filter ones
* Cleanup test artifact dependencies so no unwanted transitive
dependencies en up in the APP classloader for tests