### PR TITLE
MULE-13363: Allow access to session properties from privileged API

### DIFF
--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AbstractAuthorizationCodeRefreshTokenConfigTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AbstractAuthorizationCodeRefreshTokenConfigTestCase.java
@@ -27,7 +27,7 @@ import static org.mule.service.oauth.internal.OAuthConstants.REFRESH_TOKEN_PARAM
 
 import org.mule.extension.oauth2.internal.authorizationcode.state.ConfigOAuthContext;
 import org.mule.extension.oauth2.internal.tokenmanager.TokenManagerConfig;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.oauth.api.state.DefaultResourceOwnerOAuthContext;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.test.oauth2.AbstractOAuthAuthorizationTestCase;
@@ -71,7 +71,7 @@ public abstract class AbstractAuthorizationCodeRefreshTokenConfigTestCase extend
       throws Exception {
     configureResourceResponsesForRefreshToken(oauthConfigName, userId, failureStatusCode);
 
-    final InternalEvent result = flowRunner(flowName).withPayload("message").withVariable("userId", userId).run();
+    final BaseEvent result = flowRunner(flowName).withPayload("message").withVariable("userId", userId).run();
     assertThat(result.getMessage().getPayload().getValue(), is(RESOURCE_RESULT));
 
     wireMockRule.verify(postRequestedFor(urlEqualTo(TOKEN_PATH))


### PR DESCRIPTION
* Change security filter return type to 
* Remove some deprecated usages
* Event interface split