### PR TITLE
MULE-15539: OAuth: Provide option `encodeClientCredentialsInBody` in

### DIFF
--- a/src/main/java/org/mule/extension/oauth2/api/authorizationcode/DefaultAuthorizationCodeGrantType.java
+++ b/src/main/java/org/mule/extension/oauth2/api/authorizationcode/DefaultAuthorizationCodeGrantType.java
@@ -143,6 +143,14 @@ public class DefaultAuthorizationCodeGrantType extends AbstractGrantType {
   @Optional(defaultValue = DEFAULT_RESOURCE_OWNER_ID)
   private ParameterResolver<String> resourceOwnerId;
 
+  /**
+   * If true, the client id and client secret will be sent in the request body. Otherwise, they will be sent as basic
+   * authentication.
+   */
+  @Parameter
+  @Optional(defaultValue = "true")
+  private boolean encodeClientCredentialsInBody;
+
   @Inject
   private HttpService httpService;
 
@@ -174,14 +182,14 @@ public class DefaultAuthorizationCodeGrantType extends AbstractGrantType {
 
     OAuthAuthorizationCodeDancerBuilder dancerBuilder = configDancer(oAuthService);
 
-    if (isEncodeClientCredentialsInBody()) {
+    if (!isEncodeClientCredentialsInBody()) {
       // This dirty reflection hack is in place so that the minMuleVersion of the plugin doesn't have to be increased.
       // If at some point, the minMuleVersion of this OAuth module is increased to 4.2.0 or 4.1.4, this may be removed and the
       // encodeClientCredentialsInBody called directly.
 
       try {
         OAuthAuthorizationCodeDancerBuilder.class.getDeclaredMethod("encodeClientCredentialsInBody", boolean.class)
-            .invoke(dancerBuilder, isEncodeClientCredentialsInBody());
+            .invoke(dancerBuilder, !isEncodeClientCredentialsInBody());
       } catch (NoSuchMethodException e) {
         LOGGER.warn("`encodeClientCredentialsInBody` method not found in dancer builder but configured in authenticator."
             + " The configured value will be ignored. Check the version of the Mule Runtime.");
@@ -272,5 +280,10 @@ public class DefaultAuthorizationCodeGrantType extends AbstractGrantType {
   @Override
   public AuthorizationCodeOAuthDancer getDancer() {
     return dancer;
+  }
+
+  @Override
+  public boolean isEncodeClientCredentialsInBody() {
+    return encodeClientCredentialsInBody;
   }
 }

--- a/src/main/java/org/mule/extension/oauth2/api/clientcredentials/ClientCredentialsGrantType.java
+++ b/src/main/java/org/mule/extension/oauth2/api/clientcredentials/ClientCredentialsGrantType.java
@@ -18,6 +18,8 @@ import org.mule.extension.oauth2.internal.store.SimpleObjectStoreToMapAdapter;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.extension.api.annotation.param.Optional;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.http.api.domain.message.request.HttpRequestBuilder;
 import org.mule.runtime.oauth.api.ClientCredentialsOAuthDancer;
@@ -31,6 +33,14 @@ import java.util.concurrent.ExecutionException;
 @NoExtend
 @NoInstantiate
 public class ClientCredentialsGrantType extends AbstractGrantType {
+
+  /**
+   * If true, the client id and client secret will be sent in the request body. Otherwise, they will be sent as basic
+   * authentication.
+   */
+  @Parameter
+  @Optional(defaultValue = "false")
+  private boolean encodeClientCredentialsInBody;
 
   private ClientCredentialsOAuthDancer dancer;
 
@@ -82,4 +92,10 @@ public class ClientCredentialsGrantType extends AbstractGrantType {
   public ClientCredentialsOAuthDancer getDancer() {
     return dancer;
   }
+
+  @Override
+  public boolean isEncodeClientCredentialsInBody() {
+    return encodeClientCredentialsInBody;
+  }
+
 }

--- a/src/main/java/org/mule/extension/oauth2/internal/AbstractGrantType.java
+++ b/src/main/java/org/mule/extension/oauth2/internal/AbstractGrantType.java
@@ -76,14 +76,6 @@ public abstract class AbstractGrantType implements HttpRequestAuthentication, Mu
   private String clientSecret;
 
   /**
-   * If true, the client id and client secret will be sent in the request body. Otherwise, they will be sent as basic
-   * authentication.
-   */
-  @Parameter
-  @Optional(defaultValue = "false")
-  private boolean encodeClientCredentialsInBody;
-
-  /**
    * Scope required by this application to execute. Scopes define permissions over resources.
    */
   @Parameter
@@ -221,9 +213,7 @@ public abstract class AbstractGrantType implements HttpRequestAuthentication, Mu
     return clientId;
   }
 
-  public boolean isEncodeClientCredentialsInBody() {
-    return encodeClientCredentialsInBody;
-  }
+  public abstract boolean isEncodeClientCredentialsInBody();
 
   public String getScopes() {
     return scopes;


### PR DESCRIPTION
authCode
* Fix default behavior