### PR TITLE
MULE-15539: OAuth: Provide option `encodeClientCredentialsInBody` in

### DIFF
--- a/src/main/java/org/mule/extension/oauth2/api/authorizationcode/DefaultAuthorizationCodeGrantType.java
+++ b/src/main/java/org/mule/extension/oauth2/api/authorizationcode/DefaultAuthorizationCodeGrantType.java
@@ -189,7 +189,7 @@ public class DefaultAuthorizationCodeGrantType extends AbstractGrantType {
 
       try {
         OAuthAuthorizationCodeDancerBuilder.class.getDeclaredMethod("encodeClientCredentialsInBody", boolean.class)
-            .invoke(dancerBuilder, !isEncodeClientCredentialsInBody());
+            .invoke(dancerBuilder, isEncodeClientCredentialsInBody());
       } catch (NoSuchMethodException e) {
         LOGGER.warn("`encodeClientCredentialsInBody` method not found in dancer builder but configured in authenticator."
             + " The configured value will be ignored. Check the version of the Mule Runtime.");


### PR DESCRIPTION
(#67)

authCode
* Fix the fix