### PR TITLE
MULE-17827: tokenManager not initialized in AbstractGrantType results in

### DIFF
--- a/src/main/java/org/mule/extension/oauth2/internal/AbstractGrantType.java
+++ b/src/main/java/org/mule/extension/oauth2/internal/AbstractGrantType.java
@@ -162,9 +162,15 @@ public abstract class AbstractGrantType implements HttpRequestAuthentication, Li
   @Inject
   protected OAuthService oAuthService;
 
+  // This is used to detect that two different grant types with
+  // the default token manager are recognized as equals even if
+  // not initialized.
+  private boolean defaultTokenManager;
+
   protected void initTokenManager() throws InitialisationException {
     if (tokenManager == null) {
       this.tokenManager = TokenManagerConfig.createDefault();
+      this.defaultTokenManager = true;
     }
     initialiseIfNeeded(tokenManager, muleContext);
   }
@@ -227,7 +233,7 @@ public abstract class AbstractGrantType implements HttpRequestAuthentication, Li
       return Objects.equals(clientId, other.clientId) &&
           Objects.equals(clientSecret, other.clientSecret) &&
           Objects.equals(scopes, other.scopes) &&
-          Objects.equals(tokenManager, other.tokenManager) &&
+          (Objects.equals(tokenManager, other.tokenManager) || (this.isDefaultTokenManager() && other.isDefaultTokenManager())) &&
           Objects.equals(tokenUrl, other.tokenUrl) &&
           literalEquals(responseAccessToken, other.responseAccessToken) &&
           literalEquals(responseRefreshToken, other.responseRefreshToken) &&
@@ -291,6 +297,10 @@ public abstract class AbstractGrantType implements HttpRequestAuthentication, Li
 
   public TlsContextFactory getTlsContextFactory() {
     return tlsContext;
+  }
+
+  public boolean isDefaultTokenManager() {
+    return defaultTokenManager || tokenManager == null;
   }
 
 }

--- a/src/test/resources/client-credentials/client-credentials-dynamic-config.xml
+++ b/src/test/resources/client-credentials/client-credentials-dynamic-config.xml
@@ -8,8 +8,6 @@
        http://www.mulesoft.org/schema/mule/oauth http://www.mulesoft.org/schema/mule/oauth/current/mule-oauth.xsd
        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
 
-    <oauth:token-manager-config name="tokenManagerConfig"/>
-
     <http:request-config name="requestConfigWithOAuth">
         <http:request-connection host="localhost" port="#['${oauth.server.port}']">
             <http:authentication>
@@ -18,7 +16,6 @@
                         clientSecret="#['${client.secret}']"
                         scopes="#['${scopes}']"
                         tokenUrl="#['${token.url}']"
-                        tokenManager="tokenManagerConfig"
                         refreshTokenWhen="#[attributes.statusCode == 500]"
                         responseAccessToken="#[payload['access_token']]"
                         responseExpiresIn="#[payload['expires_in']]">


### PR DESCRIPTION
leak of dynamic configs.