### PR TITLE
MULE-18307: Using "payload" in an expression for refreshTokenWhen property results in an Error

### DIFF
--- a/src/main/java/org/mule/extension/oauth2/internal/DeferredExpressionResolver.java
+++ b/src/main/java/org/mule/extension/oauth2/internal/DeferredExpressionResolver.java
@@ -55,7 +55,7 @@ public class DeferredExpressionResolver {
                         .build(), DataType.fromType(DataType.class)))
         .build();
 
-    return (T) evaluator.evaluate(expr, resultContext).getValue();
+    return (T) evaluator.evaluate(expr, DataType.BOOLEAN, resultContext).getValue();
   }
 
   public <T> String getExpression(Literal<T> literal) {

--- a/src/main/java/org/mule/extension/oauth2/internal/DeferredExpressionResolver.java
+++ b/src/main/java/org/mule/extension/oauth2/internal/DeferredExpressionResolver.java
@@ -8,6 +8,7 @@ package org.mule.extension.oauth2.internal;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static org.mule.runtime.api.metadata.DataType.BOOLEAN;
 import static org.mule.runtime.api.metadata.MediaType.ANY;
 
 import org.mule.runtime.api.el.BindingContext;
@@ -55,7 +56,7 @@ public class DeferredExpressionResolver {
                         .build(), DataType.fromType(DataType.class)))
         .build();
 
-    return (T) evaluator.evaluate(expr, DataType.BOOLEAN, resultContext).getValue();
+    return (T) evaluator.evaluate(expr, BOOLEAN, resultContext).getValue();
   }
 
   public <T> String getExpression(Literal<T> literal) {

--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase.java
@@ -71,9 +71,9 @@ public abstract class AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase ex
     return "authorization-code/authorization-code-refresh-token-when-config.xml";
   }
 
-  protected void executeRefreshTokenWhen(String flowName, String oauthConfigName, String userId, int failureStatusCode)
+  protected void executeRefreshTokenWhen(String flowName, String userId, int failureStatusCode)
       throws Exception {
-    configureResourceResponsesForRefreshTokenWhen(oauthConfigName, userId, failureStatusCode);
+    configureResourceResponsesForRefreshTokenWhen(userId, failureStatusCode);
 
     final CoreEvent result = flowRunner(flowName).withPayload("message").withVariable("userId", userId)
         .withVariable("headerName", TEST_HEADER_NAME).withVariable("headerValue", TEST_HEADER_VALUE).run();
@@ -90,7 +90,7 @@ public abstract class AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase ex
                         postRequestedFor(urlEqualTo(RESOURCE_PATH)).withHeader(TEST_HEADER_NAME, containing(TEST_HEADER_VALUE)));
   }
 
-  private void configureResourceResponsesForRefreshTokenWhen(String oauthConfigName, String userId, int failureStatusCode) {
+  private void configureResourceResponsesForRefreshTokenWhen(String userId, int failureStatusCode) {
     configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(REFRESHED_ACCESS_TOKEN);
 
     wireMockRule

--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.oauth2.internal.authorizationcode.functional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.runtime.http.api.HttpHeaders.Names.AUTHORIZATION;
+import static org.mule.service.oauth.internal.OAuthConstants.CLIENT_ID_PARAMETER;
+import static org.mule.service.oauth.internal.OAuthConstants.CLIENT_SECRET_PARAMETER;
+import static org.mule.service.oauth.internal.OAuthConstants.GRANT_TYPE_PARAMETER;
+import static org.mule.service.oauth.internal.OAuthConstants.GRANT_TYPE_REFRESH_TOKEN;
+import static org.mule.service.oauth.internal.OAuthConstants.REFRESH_TOKEN_PARAMETER;
+
+import org.junit.Rule;
+import org.mule.extension.oauth2.api.tokenmanager.TokenManagerConfig;
+import org.mule.extension.oauth2.internal.authorizationcode.state.ConfigOAuthContext;
+import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext;
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.mule.test.oauth2.AbstractOAuthAuthorizationTestCase;
+
+public abstract class AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase extends AbstractOAuthAuthorizationTestCase {
+
+  private static final String RESOURCE_PATH = "/resource";
+  public static final String RESOURCE_RESULT = "resource result";
+  public static final String REFRESHED_ACCESS_TOKEN = "rbBQLgJXBEYo83K4Fqs4guasdfsdfa";
+
+  public static final String TEST_HEADER_NAME = "test_name";
+  public static final String TEST_HEADER_VALUE = "test_value";
+
+  @Rule
+  public SystemProperty originalPayload = new SystemProperty("payload.original", TEST_PAYLOAD);
+  @Rule
+  public SystemProperty localAuthorizationUrl =
+      new SystemProperty("local.authorization.url",
+                         format("http://localhost:%d/authorization", localHostPort.getNumber()));
+  @Rule
+  public SystemProperty authorizationUrl =
+      new SystemProperty("authorization.url", format("http://localhost:%d" + AUTHORIZE_PATH, oauthServerPort.getNumber()));
+  @Rule
+  public SystemProperty redirectUrl =
+      new SystemProperty("redirect.url", format("http://localhost:%d/redirect", localHostPort.getNumber()));
+  @Rule
+  public SystemProperty tokenUrl =
+      new SystemProperty("token.url", format("http://localhost:%d" + TOKEN_PATH, oauthServerPort.getNumber()));
+  @Rule
+  public SystemProperty tokenHost = new SystemProperty("token.host", format("localhost"));
+  @Rule
+  public SystemProperty tokenPort = new SystemProperty("token.port", valueOf(oauthServerPort.getNumber()));
+  @Rule
+  public SystemProperty tokenPath = new SystemProperty("token.path", TOKEN_PATH);
+
+  @Override
+  protected String getConfigFile() {
+    return "authorization-code/authorization-code-refresh-token-when-config.xml";
+  }
+
+  protected void executeRefreshTokenWhen(String flowName, String oauthConfigName, String userId, int failureStatusCode)
+          throws Exception {
+    configureResourceResponsesForRefreshTokenWhen(oauthConfigName, userId, failureStatusCode);
+
+    final CoreEvent result = flowRunner(flowName).withPayload("message").withVariable("userId", userId)
+            .withVariable("headerName", TEST_HEADER_NAME).withVariable("headerValue", TEST_HEADER_VALUE).run();
+    assertThat(result.getMessage().getPayload().getValue(), is(RESOURCE_RESULT));
+
+    wireMockRule.verify(postRequestedFor(urlEqualTo(TOKEN_PATH))
+            .withRequestBody(containing(CLIENT_ID_PARAMETER + "=" + encode(clientId.getValue(), UTF_8.name())))
+            .withRequestBody(containing(REFRESH_TOKEN_PARAMETER + "=" + encode(REFRESH_TOKEN, UTF_8.name())))
+            .withRequestBody(containing(CLIENT_SECRET_PARAMETER + "=" + encode(clientSecret.getValue(), UTF_8.name())))
+            .withRequestBody(containing(GRANT_TYPE_PARAMETER + "=" + encode(GRANT_TYPE_REFRESH_TOKEN, UTF_8.name()))));
+
+    wireMockRule.verify(2, postRequestedFor(urlEqualTo(RESOURCE_PATH)).withRequestBody(equalTo(TEST_PAYLOAD)));
+    wireMockRule.verify(2,
+            postRequestedFor(urlEqualTo(RESOURCE_PATH)).withHeader(TEST_HEADER_NAME, containing(TEST_HEADER_VALUE)));
+  }
+
+  private void configureResourceResponsesForRefreshTokenWhen(String oauthConfigName, String userId, int failureStatusCode) {
+    configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(REFRESHED_ACCESS_TOKEN);
+
+    wireMockRule
+            .stubFor(post(urlEqualTo(RESOURCE_PATH)).withHeader(AUTHORIZATION, containing(REFRESHED_ACCESS_TOKEN))
+                    .willReturn(aResponse().withStatus(200).withBody(RESOURCE_RESULT)));
+    wireMockRule.stubFor(post(urlEqualTo(RESOURCE_PATH)).withHeader(AUTHORIZATION, containing(ACCESS_TOKEN))
+            .willReturn(aResponse().withStatus(failureStatusCode).withHeader("Content-Type", MediaType.APPLICATION_JSON.toString())
+                    .withBody("{\"success\":\"false\", \"errors\":[{\"code\":\"601\"}]}")));
+
+    final ConfigOAuthContext configOAuthContext = getTokenManagerConfig().getConfigOAuthContext();
+    final ResourceOwnerOAuthContext resourceOwnerOauthContext = configOAuthContext.getContextForResourceOwner(userId);
+    setTokens(resourceOwnerOauthContext, ACCESS_TOKEN, REFRESH_TOKEN);
+    configOAuthContext.updateResourceOwnerOAuthContext(resourceOwnerOauthContext);
+  }
+
+  protected abstract TokenManagerConfig getTokenManagerConfig();
+
+}
+

--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AuthorizationCodeRefreshTokenWhenConfigTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AuthorizationCodeRefreshTokenWhenConfigTestCase.java
@@ -6,22 +6,22 @@
  */
 package org.mule.test.oauth2.internal.authorizationcode.functional;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.mule.extension.http.api.request.validator.ResponseValidatorTypedException;
 import org.mule.extension.oauth2.api.tokenmanager.TokenManagerConfig;
 import org.mule.functional.api.exception.ExpectedError;
 
+import javax.inject.Inject;
+
 public class AuthorizationCodeRefreshTokenWhenConfigTestCase extends AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase {
+
+  @Inject
+  TokenManagerConfig tokenManagerConfig;
 
   @Rule
   public ExpectedError expectedError = ExpectedError.none();
-
-  public static final String SINGLE_TENANT_OAUTH_CONFIG = "oauthConfig";
 
   @Override
   protected String getConfigFile() {
@@ -30,12 +30,12 @@ public class AuthorizationCodeRefreshTokenWhenConfigTestCase extends AbstractAut
 
   @Test
   public void afterFailureDoRefreshWhenTokenWithDefaultValueNoResourceOwnerId() throws Exception {
-    executeRefreshTokenWhen("testFlowRefreshTokenWhen", SINGLE_TENANT_OAUTH_CONFIG, DEFAULT_RESOURCE_OWNER_ID, 403);
+    executeRefreshTokenWhen("testFlowRefreshTokenWhen", DEFAULT_RESOURCE_OWNER_ID, 403);
   }
 
   @Override
   protected TokenManagerConfig getTokenManagerConfig() {
-    return registry.<TokenManagerConfig>lookupByName(SINGLE_TENANT_OAUTH_CONFIG).get();
+    return tokenManagerConfig;
   }
 
 }

--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AuthorizationCodeRefreshTokenWhenConfigTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/functional/AuthorizationCodeRefreshTokenWhenConfigTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.oauth2.internal.authorizationcode.functional;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mule.extension.http.api.request.validator.ResponseValidatorTypedException;
+import org.mule.extension.oauth2.api.tokenmanager.TokenManagerConfig;
+import org.mule.functional.api.exception.ExpectedError;
+
+public class AuthorizationCodeRefreshTokenWhenConfigTestCase extends AbstractAuthorizationCodeRefreshTokenWhenConfigTestCase {
+
+  @Rule
+  public ExpectedError expectedError = ExpectedError.none();
+
+  public static final String SINGLE_TENANT_OAUTH_CONFIG = "oauthConfig";
+
+  @Override
+  protected String getConfigFile() {
+    return "authorization-code/authorization-code-refresh-token-when-config.xml";
+  }
+
+  @Test
+  public void afterFailureDoRefreshWhenTokenWithDefaultValueNoResourceOwnerId() throws Exception {
+    executeRefreshTokenWhen("testFlowRefreshTokenWhen", SINGLE_TENANT_OAUTH_CONFIG, DEFAULT_RESOURCE_OWNER_ID, 403);
+  }
+
+  @Override
+  protected TokenManagerConfig getTokenManagerConfig() {
+    return registry.<TokenManagerConfig>lookupByName(SINGLE_TENANT_OAUTH_CONFIG).get();
+  }
+
+}

--- a/src/test/resources/authorization-code/authorization-code-refresh-token-when-config.xml
+++ b/src/test/resources/authorization-code/authorization-code-refresh-token-when-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:oauth="http://www.mulesoft.org/schema/mule/oauth"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/oauth http://www.mulesoft.org/schema/mule/oauth/current/mule-oauth.xsd
+       http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+
+    <oauth:token-manager-config name="oauthConfig"/>
+
+    <http:request-config name="requestConfig">
+        <http:request-connection host="localhost" port="${oauth.server.port}">
+            <http:authentication>
+                <oauth:authorization-code-grant-type
+                        clientId="${client.id}"
+                        clientSecret="${client.secret}"
+                        localCallbackUrl="${local.callback.url}"
+                        externalCallbackUrl="${local.callback.url}"
+                        tokenManager="oauthConfig"
+                        localAuthorizationUrl="${local.authorization.url}"
+                        authorizationUrl="${authorization.url}"
+                        refreshTokenWhen="#[payload['success'] == 'false' and (payload['errors'][0].code == '601' or payload['errors'][0].code == '602')]"
+                        tokenUrl="${token.url}">
+                </oauth:authorization-code-grant-type>
+            </http:authentication>
+        </http:request-connection>
+    </http:request-config>
+
+    <flow name="testFlowRefreshTokenWhen">
+        <set-payload value="${payload.original}"/>
+        <http:request path="/resource" method="POST" config-ref="requestConfig">
+            <http:headers>
+                #[{
+                '$(vars.headerName)' : vars.headerValue
+                }]
+            </http:headers>
+        </http:request>
+        <object-to-string-transformer />
+    </flow>
+
+</mule>


### PR DESCRIPTION
Change the method that is invoked to evaluate the refreshTokenWhen expression for a method that takes the expected output type as parameter to prevent DataWeave from returning anything other than the expected boolean.