### PR TITLE
OAMOD-7: Remove reference to runtime.version on munit-extensions-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
                             <includeSnapshots>true</includeSnapshots>
                         </discoverRuntimes>
                     </runtimeConfiguration>
-                    <runtimeVersion>${runtime.version}</runtimeVersion>
                     <munitTest>${munit.test}</munitTest>
                 </configuration>
                 <dependencies>


### PR DESCRIPTION
Otherwise, the `runtimeVersion` property is being ignored when calling `mvn verify`.