### PR TITLE
OAMOD-7: Remove reference to runtime.version on munit-extensions-maven-plugin (#179)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
                             <includeSnapshots>true</includeSnapshots>
                         </discoverRuntimes>
                     </runtimeConfiguration>
-                    <runtimeVersion>${runtime.version}</runtimeVersion>
                     <munitTest>${munit.test}</munitTest>
                 </configuration>
                 <dependencies>


### PR DESCRIPTION
(cherry picked from commit cc3ed783a837f0dbed72330b7b457c2f2a3467b4)