### PR TITLE
Cherry picks 20210712-20200902 from master to 1.1.x

### DIFF
--- a/formatter.xml
+++ b/formatter.xml
@@ -20,6 +20,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <muleHttpConnectorVersion>1.5.23</muleHttpConnectorVersion>
         <muleSocketsConnectorVersion>1.1.5</muleSocketsConnectorVersion>
-        <muleObjectStoreConnectorTestVersion>1.1.5</muleObjectStoreConnectorTestVersion>
+        <muleObjectStoreConnectorTestVersion>1.1.6</muleObjectStoreConnectorTestVersion>
         <commonsCodecVersion>1.15</commonsCodecVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
         <munit.extensions.maven.plugin.version>1.1.0</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.1</munit.version>
+        <munit.version>2.3.2</munit.version>
         <mtf-tools.version>1.0.0</mtf-tools.version>
         <mavenResources.version>3.2.0</mavenResources.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.5</version>
+            <version>4.5.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.1.17-SNAPSHOT</version>
 
     <properties>
-        <muleHttpConnectorVersion>1.5.21</muleHttpConnectorVersion>
+        <muleHttpConnectorVersion>1.5.22</muleHttpConnectorVersion>
         <muleSocketsConnectorVersion>1.1.5</muleSocketsConnectorVersion>
         <muleObjectStoreConnectorTestVersion>1.1.5</muleObjectStoreConnectorTestVersion>
         <commonsCodecVersion>1.15</commonsCodecVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.1.17-SNAPSHOT</version>
 
     <properties>
-        <muleHttpConnectorVersion>1.5.20</muleHttpConnectorVersion>
+        <muleHttpConnectorVersion>1.5.21</muleHttpConnectorVersion>
         <muleSocketsConnectorVersion>1.1.5</muleSocketsConnectorVersion>
         <muleObjectStoreConnectorTestVersion>1.1.5</muleObjectStoreConnectorTestVersion>
         <commonsCodecVersion>1.15</commonsCodecVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <muleHttpConnectorVersion>1.5.20</muleHttpConnectorVersion>
         <muleSocketsConnectorVersion>1.1.5</muleSocketsConnectorVersion>
         <muleObjectStoreConnectorTestVersion>1.1.3</muleObjectStoreConnectorTestVersion>
-        <commonsCodecVersion>1.13</commonsCodecVersion>
+        <commonsCodecVersion>1.15</commonsCodecVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
         <!-- Remove when a new parent version with MTF is available -->

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.3.5</version>
+            <version>4.5.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
                     <dependency>
                         <groupId>org.mule.module</groupId>
                         <artifactId>mule-java-module</artifactId>
-                        <version>1.2.7</version>
+                        <version>1.2.8</version>
                         <classifier>mule-plugin</classifier>
                     </dependency>
                 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- Remove when a new parent version with MTF is available -->
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
-        <munit.extensions.maven.plugin.version>1.0.0</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.1.0</munit.extensions.maven.plugin.version>
         <munit.version>2.3.1</munit.version>
         <mtf-tools.version>1.0.0</mtf-tools.version>
         <mavenResources.version>3.2.0</mavenResources.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
         <munit.extensions.maven.plugin.version>1.0.0</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.0</munit.version>
+        <munit.version>2.3.1</munit.version>
         <mtf-tools.version>1.0.0</mtf-tools.version>
         <mavenResources.version>3.0.2</mavenResources.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3.2</version>
+            <version>4.4.14</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- Remove when a new parent version with MTF is available -->
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
-        <munit.extensions.maven.plugin.version>1.1.0</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.1.1</munit.extensions.maven.plugin.version>
         <munit.version>2.3.2</munit.version>
         <mtf-tools.version>1.0.0</mtf-tools.version>
         <mavenResources.version>3.2.0</mavenResources.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <muleHttpConnectorVersion>1.5.20</muleHttpConnectorVersion>
         <muleSocketsConnectorVersion>1.1.5</muleSocketsConnectorVersion>
-        <muleObjectStoreConnectorTestVersion>1.1.3</muleObjectStoreConnectorTestVersion>
+        <muleObjectStoreConnectorTestVersion>1.1.5</muleObjectStoreConnectorTestVersion>
         <commonsCodecVersion>1.15</commonsCodecVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
                     <dependency>
                         <groupId>org.mule.module</groupId>
                         <artifactId>mule-java-module</artifactId>
-                        <version>1.2.6</version>
+                        <version>1.2.7</version>
                         <classifier>mule-plugin</classifier>
                     </dependency>
                 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <munit.extensions.maven.plugin.version>1.0.0</munit.extensions.maven.plugin.version>
         <munit.version>2.3.1</munit.version>
         <mtf-tools.version>1.0.0</mtf-tools.version>
-        <mavenResources.version>3.0.2</mavenResources.version>
+        <mavenResources.version>3.2.0</mavenResources.version>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.1.17-SNAPSHOT</version>
 
     <properties>
-        <muleHttpConnectorVersion>1.5.22</muleHttpConnectorVersion>
+        <muleHttpConnectorVersion>1.5.23</muleHttpConnectorVersion>
         <muleSocketsConnectorVersion>1.1.5</muleSocketsConnectorVersion>
         <muleObjectStoreConnectorTestVersion>1.1.5</muleObjectStoreConnectorTestVersion>
         <commonsCodecVersion>1.15</commonsCodecVersion>


### PR DESCRIPTION
Cherry picking changes from 2020/09/02 to 2021/07/12 from `master` to `support/1.1.x`. Most of these are just dependency version bumps.